### PR TITLE
Firefox Mobile: Popup is a page

### DIFF
--- a/Extension/popup.html
+++ b/Extension/popup.html
@@ -1,4 +1,4 @@
-<html dir="ltr" lang="en"><head><meta charset="utf-8">
+<html dir="ltr" lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
 body, html {
     margin: 0;

--- a/Extension/popup.js
+++ b/Extension/popup.js
@@ -20,8 +20,10 @@ chrome.tabs.query({
     });
 
     document.querySelector("#unhandled").addEventListener("click", ()=>{
-        console.log("Sending report of unhandled CMP: ", url);
-
-        fetch("https://gdprconsent.projects.cavi.au.dk/report.php?url="+encodeURIComponent(url));
+	if (confirm('Submit '+url+' to our list of sites where autofill did not work?')) {
+	    // Save it
+            console.log("Sending report of unhandled CMP: ", url);
+            fetch("https://gdprconsent.projects.cavi.au.dk/report.php?url="+encodeURIComponent(url));
+	}
     });
 });


### PR DESCRIPTION
- Allow Firefox Mobile to show addon popup as a full page with proper device text size
- Bonus feature: Add a confirmation dialog when submitting suggested sites