### PR TITLE
Update Rules.json: add English selector for social media consent

### DIFF
--- a/Rules.json
+++ b/Rules.json
@@ -3017,6 +3017,22 @@
                     "type": "A"
                   },
                   {
+                    "description": "Social networks",
+                    "falseAction": {
+                      "target": {
+                        "selector": ".didomi-components-radio__option[aria-describedby=didomi-purpose-social_media]:first-child"
+                      },
+                      "type": "click"
+                    },
+                    "trueAction": {
+                      "target": {
+                        "selector": ".didomi-components-radio__option[aria-describedby=didomi-purpose-social_media]:last-child"
+                      },
+                      "type": "click"
+                    },
+                    "type": "A"
+                  },
+                  {
                     "description": "Content selection",
                     "falseAction": {
                       "target": {


### PR DESCRIPTION
Hello. Love the extension, always wanted to contribute. Today is the day.

I noticed that on a news site using "didomi" as consent mechanism, the "Social Media" option was not selected, which blocked Consent-O-Matic from doing its work.
I checked the `Rules.json` file for "didomi" and noticed that there was a french selector for selecting the consent but the English version (which I had on the website) was missing.
In this PR, I added the English selector.

Let me know if this needs additional work. One thing I could not find information on is if the `description` of the `consents` needed to be unique. For now, I duplicated the rule and kept the original description.

Happy to help.


