### PR TITLE
Fix missing comma in Rules.json

### DIFF
--- a/Rules.json
+++ b/Rules.json
@@ -3653,7 +3653,7 @@
                 "name": "HIDE_CMP"
             }
         ]
-    }    
+    },
     "oil": {
       "detectors": [
         {


### PR DESCRIPTION
The last commit introduced a syntax error in Rules.json due to this comma being missing. This PR fixes Rules.json, making it valid JSON.