### PR TITLE
Add option to disable modal (#54)

### DIFF
--- a/Extension/ConsentEngine.js
+++ b/Extension/ConsentEngine.js
@@ -227,7 +227,13 @@ class ConsentEngine {
         }
 
         this.modal = document.createElement("div");
-        this.modal.classList.add("ConsentOMatic-Progress-Dialog-Modal");
+
+        GDPRConfig.getOptions().then(options => {
+            if (options.disableModal && options.disableModal == true) {
+                this.modal.classList.add("ConsentOMatic-Progress-Dialog-Modal");
+            }
+        });
+
         this.dialog = document.createElement("div");
         this.dialog.classList.add("ConsentOMatic-Progress-Dialog");
         let header = document.createElement("h1");

--- a/Extension/GDPRConfig.js
+++ b/Extension/GDPRConfig.js
@@ -31,7 +31,19 @@ class GDPRConfig {
             });
         });
     }
-    
+
+    static getOptions() {
+        return new Promise((resolve, reject) => {
+            chrome.storage.sync.get({
+                options: {
+                    disableModal: false
+                }
+            }, (result) => {
+                resolve(result.options);
+            });
+        });
+    }
+
     static getDebugValues() {
         return new Promise((resolve, reject) => {
             chrome.storage.sync.get({
@@ -40,7 +52,7 @@ class GDPRConfig {
                 resolve(result.debugFlags);
             });
         });
-    }    
+    }
 
     static getCustomRuleLists() {
         return new Promise((resolve, reject) => {
@@ -133,7 +145,7 @@ class GDPRConfig {
             });
         });
     }
-    
+
     static async getDebugFlags() {
         let debugValues = await GDPRConfig.getDebugValues();
 
@@ -241,7 +253,19 @@ class GDPRConfig {
             });
         });
     }
-    
+
+    static setOptions() {
+        return new Promise((resolve, reject)=>{
+            chrome.storage.sync.set({
+                options: {
+                    disableModal: false
+                }
+            }, () => {
+                resolve();
+            });
+        });
+    }
+
     static setDebugFlags(newDebugFlags) {
         return new Promise((resolve, reject)=>{
             newDebugFlags = Object.assign({}, GDPRConfig.defaultDebugFlags, newDebugFlags);
@@ -252,7 +276,7 @@ class GDPRConfig {
                 resolve();
             });
         });
-    }    
+    }
 
     static clearRuleCache() {
         return new Promise((resolve, reject)=>{

--- a/Extension/language.js
+++ b/Extension/language.js
@@ -8,32 +8,38 @@ const translations = {
     "EXTENSION_SUBTITLE": {
         "en": "Your Choice - Applied Everywhere",
         "da": "Dit valg - Anvendt overalt",
-	      "de": "Ihre Wahl - Überall angewendet",
-	      "pt": "Sua Escolha - Aplicadada em todos os lugares"
+        "de": "Ihre Wahl - Überall angewendet",
+        "pt": "Sua Escolha - Aplicadada em todos os lugares"
     },
     "YOUR_CHOICE": {
         "en": "Your Choice",
         "da": "Dit valg",
-	      "de": "Ihre Wahl",
-	      "pt": "Sua Escolha"
+        "de": "Ihre Wahl",
+        "pt": "Sua Escolha"
     },
     "RULE_LIST": {
         "en": "Rule Lists",
         "da": "Regler",
-	      "de": "Regellisten",
-	      "pt": "Lista de Regras"
+        "de": "Regellisten",
+        "pt": "Lista de Regras"
+    },
+    "OPTIONS": {
+        "en": "Options",
+        "da": "Options",
+        "de": "Options",
+        "pt": "Options"
     },
     "ABOUT": {
         "en": "About",
         "da": "Info",
         "de": "Information",
-	      "pt": "Sobre"
+	    "pt": "Sobre"
     },
     "DEBUG": {
         "en": "Debug",
         "da": "Debug",
-	      "de": "Debug",
-	      "pt": "Debug"
+	    "de": "Debug",
+	    "pt": "Debug"
     },
     "CHOICE_DESCRIPTION": {
         "en": "Configure what categories of tracking you would like to allow. Consent-O-Matic then fills out consent popups as best as possible based on your preferences. All tracking is rejected by default.",
@@ -1023,7 +1029,7 @@ class Language {
         if(lang == null) {
             lang = "en";
         }
-        
+
         document.querySelector("html").lang = lang;
 
         const allTextNodes = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);

--- a/Extension/options.html
+++ b/Extension/options.html
@@ -271,6 +271,7 @@
         <ul>
             <li class="menuitem choices active">[[YOUR_CHOICE]]</li>
             <li class="menuitem rules">[[RULE_LIST]]</li>
+            <li class="menuitem options">[[OPTIONS]]</li>
             <li class="menuitem about">[[ABOUT]]</li>
             <li class="menuitem debug">[[DEBUG]]</li>
         </ul>
@@ -302,6 +303,11 @@
                     [[RULE_GENERATOR_DESCRIPTION]]
                 </p>
                 <button id="rulesEditor">[[OPEN_RULE_GENERATOR]]</button>
+            </div>
+        </div>
+        <div class="tab tab_options" style="display: none;">
+            <div class="helptext">
+                [[OPTIONS_DESCRIPTION]]
             </div>
         </div>
         <div class="tab tab_about" style="display:none">

--- a/Extension/options.js
+++ b/Extension/options.js
@@ -13,6 +13,10 @@ document.querySelector(".header .menuitem.rules").addEventListener("click", func
     tabChanged(this);
     document.querySelector(".tab_rl").style.display = "block";
 });
+document.querySelector(".header .menuitem.options").addEventListener("click", function (evt) {
+    tabChanged(this);
+    document.querySelector(".tab_options").style.display = "block";
+});
 document.querySelector(".header .menuitem.about").addEventListener("click", function (evt) {
     tabChanged(this);
     document.querySelector(".tab_about").style.display = "block";
@@ -137,6 +141,8 @@ function saveSettings() {
         consentValues[input.id] = input.checked;
     });
     GDPRConfig.setConsentValues(consentValues);
+
+    GDPRConfig.setOptions();
 
     let debugFlags = {};
     debugUL.querySelectorAll("li input").forEach((input) => {


### PR DESCRIPTION
First off I want to apologise for this PR, I am not familiar with extension development and can barely read JavaScript, any help to improve this would be greatly appreciated.

As mentioned in #54 I am wanting an option to disable the consent modal since it can be very frustrating to wait a relatively long time for elaborate or slow consent forms.

This PR (should) add an option for the user to decide whether they are aware of the risk of this option and want to activate it.

# Work in progress
Currently, I've just added an option which can not be managed via the UI, I still plan to do that. 