### PR TITLE
Add cookiewow

### DIFF
--- a/rules-list.json
+++ b/rules-list.json
@@ -62,6 +62,7 @@
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/pricerunnerdk.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/nordnetdk.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/danskebank.json",
-    "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/ku.dk.json"
+    "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/ku.dk.json",
+    "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/cookiewow.json"
   ]
 }

--- a/rules/cookiewow.json
+++ b/rules/cookiewow.json
@@ -1,0 +1,234 @@
+{
+	"$schema": "../rules.schema.json",
+	"cookiewow": {
+		"detectors": [
+			{
+				"presentMatcher": {
+					"type": "css",
+					"target": {
+						"selector": ".cwc-banner-container"
+					}
+				},
+				"showingMatcher": {
+					"type": "css",
+					"target": {
+						"selector": ".cwc-banner-container",
+						"displayFilter": true
+					}
+				}
+			}
+		],
+		"methods": [
+			{
+				"name": "OPEN_OPTIONS",
+				"action": {
+					"type": "click",
+					"target": {
+						"selector": ".cwc-setting-button"
+					}
+				}
+			},
+			{
+				"name": "DO_CONSENT",
+				"action": {
+					"type": "consent",
+					"consents": [
+						{
+							"type": "B",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "Analytics"
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".cwc-switch"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "Analytics"
+								}
+							}
+						},
+						{
+							"type": "B",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "คุกกี้ในส่วนวิเคราะห์"
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".cwc-switch"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "คุกกี้ในส่วนวิเคราะห์"
+								}
+							}
+						},
+						{
+							"type": "B",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "访问分析Cookie"
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".cwc-switch"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "访问分析Cookie"
+								}
+							}
+						},
+						{
+							"type": "B",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "トラフィック分析Cookie"
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".cwc-switch"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "トラフィック分析Cookie"
+								}
+							}
+						},
+						{
+							"type": "F",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "Marketing"
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".cwc-switch"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "Marketing"
+								}
+							}
+						},
+						{
+							"type": "F",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "คุกกี้ในส่วนการตลาด"
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".cwc-switch"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "คุกกี้ในส่วนการตลาด"
+								}
+							}
+						},
+						{
+							"type": "F",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "访问分析Cookie"
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".cwc-switch"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "访问分析Cookie"
+								}
+							}
+						},
+						{
+							"type": "F",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "トラフィック分析Cookie"
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".cwc-switch"
+								},
+								"parent": {
+									"selector": ".cwc-category-item",
+									"textFilter": "トラフィック分析Cookie"
+								}
+							}
+						}
+					]
+				}
+			},
+			{
+				"name": "SAVE_CONSENT",
+				"action": {
+					"type": "click",
+					"target": {
+						"selector": ".cwc-save-setting-wrapper button"
+					}
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
Cookiewow.com is a Thai cookie consent provider, used by some Thai sites like thestandard.co, techsauce.co .