### PR TITLE
Add DesignilPDPA, fix Cookiewow doesn't actually change consent state

### DIFF
--- a/rules-list.json
+++ b/rules-list.json
@@ -63,6 +63,7 @@
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/nordnetdk.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/danskebank.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/ku.dk.json",
-    "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/cookiewow.json"
+    "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/cookiewow.json",
+    "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/designilpdpa.json"
   ]
 }

--- a/rules/cookiewow.json
+++ b/rules/cookiewow.json
@@ -31,191 +31,102 @@
 			{
 				"name": "DO_CONSENT",
 				"action": {
-					"type": "consent",
-					"consents": [
+					"type": "list",
+					"actions": [
 						{
-							"type": "B",
-							"matcher": {
-								"type": "checkbox",
-								"target": {
-									"selector": "input"
+							"type": "consent",
+							"consents": [
+								{
+									"type": "B",
+									"matcher": {
+										"type": "checkbox",
+										"target": {
+											"selector": "input"
+										},
+										"parent": {
+											"selector": ".cwc-category-item",
+											"childFilter": {
+												"target": {
+													"selector": ".cwc-category-item-title",
+													"textFilter": [
+														"Analytics",
+														"คุกกี้ในส่วนวิเคราะห์",
+														"访问分析Cookie",
+														"トラフィック分析Cookie"
+													]
+												}
+											}
+										}
+									},
+									"toggleAction": {
+										"type": "click",
+										"target": {
+											"selector": ".cwc-switch"
+										},
+										"parent": {
+											"selector": ".cwc-category-item",
+											"childFilter": {
+												"target": {
+													"selector": ".cwc-category-item-title",
+													"textFilter": [
+														"Analytics",
+														"คุกกี้ในส่วนวิเคราะห์",
+														"访问分析Cookie",
+														"トラフィック分析Cookie"
+													]
+												}
+											}
+										}
+									}
 								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "Analytics"
+								{
+									"type": "F",
+									"matcher": {
+										"type": "checkbox",
+										"target": {
+											"selector": "input"
+										},
+										"parent": {
+											"selector": ".cwc-category-item",
+											"childFilter": {
+												"target": {
+													"selector": ".cwc-category-item-title",
+													"textFilter": [
+														"Marketing",
+														"คุกกี้ในส่วนการตลาด",
+														"访问分析Cookie",
+														"トラフィック分析Cookie"
+													]
+												}
+											}
+										}
+									},
+									"toggleAction": {
+										"type": "click",
+										"target": {
+											"selector": ".cwc-switch"
+										},
+										"parent": {
+											"selector": ".cwc-category-item",
+											"childFilter": {
+												"target": {
+													"selector": ".cwc-category-item-title",
+													"textFilter": [
+														"Marketing",
+														"คุกกี้ในส่วนการตลาด",
+														"访问分析Cookie",
+														"トラフィック分析Cookie"
+													]
+												}
+											}
+										}
+									}
 								}
-							},
-							"toggleAction": {
-								"type": "click",
-								"target": {
-									"selector": ".cwc-switch"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "Analytics"
-								}
-							}
+							]
 						},
 						{
-							"type": "B",
-							"matcher": {
-								"type": "checkbox",
-								"target": {
-									"selector": "input"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "คุกกี้ในส่วนวิเคราะห์"
-								}
-							},
-							"toggleAction": {
-								"type": "click",
-								"target": {
-									"selector": ".cwc-switch"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "คุกกี้ในส่วนวิเคราะห์"
-								}
-							}
-						},
-						{
-							"type": "B",
-							"matcher": {
-								"type": "checkbox",
-								"target": {
-									"selector": "input"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "访问分析Cookie"
-								}
-							},
-							"toggleAction": {
-								"type": "click",
-								"target": {
-									"selector": ".cwc-switch"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "访问分析Cookie"
-								}
-							}
-						},
-						{
-							"type": "B",
-							"matcher": {
-								"type": "checkbox",
-								"target": {
-									"selector": "input"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "トラフィック分析Cookie"
-								}
-							},
-							"toggleAction": {
-								"type": "click",
-								"target": {
-									"selector": ".cwc-switch"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "トラフィック分析Cookie"
-								}
-							}
-						},
-						{
-							"type": "F",
-							"matcher": {
-								"type": "checkbox",
-								"target": {
-									"selector": "input"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "Marketing"
-								}
-							},
-							"toggleAction": {
-								"type": "click",
-								"target": {
-									"selector": ".cwc-switch"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "Marketing"
-								}
-							}
-						},
-						{
-							"type": "F",
-							"matcher": {
-								"type": "checkbox",
-								"target": {
-									"selector": "input"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "คุกกี้ในส่วนการตลาด"
-								}
-							},
-							"toggleAction": {
-								"type": "click",
-								"target": {
-									"selector": ".cwc-switch"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "คุกกี้ในส่วนการตลาด"
-								}
-							}
-						},
-						{
-							"type": "F",
-							"matcher": {
-								"type": "checkbox",
-								"target": {
-									"selector": "input"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "访问分析Cookie"
-								}
-							},
-							"toggleAction": {
-								"type": "click",
-								"target": {
-									"selector": ".cwc-switch"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "访问分析Cookie"
-								}
-							}
-						},
-						{
-							"type": "F",
-							"matcher": {
-								"type": "checkbox",
-								"target": {
-									"selector": "input"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "トラフィック分析Cookie"
-								}
-							},
-							"toggleAction": {
-								"type": "click",
-								"target": {
-									"selector": ".cwc-switch"
-								},
-								"parent": {
-									"selector": ".cwc-category-item",
-									"textFilter": "トラフィック分析Cookie"
-								}
-							}
+							"type": "wait",
+							"waitTime": 250
 						}
 					]
 				}
@@ -226,6 +137,15 @@
 					"type": "click",
 					"target": {
 						"selector": ".cwc-save-setting-wrapper button"
+					}
+				}
+			},
+			{
+				"name": "HIDE_CMP",
+				"action": {
+					"type": "hide",
+					"target": {
+						"selector": ".cwc-sdk-container"
 					}
 				}
 			}

--- a/rules/designilpdpa.json
+++ b/rules/designilpdpa.json
@@ -163,6 +163,32 @@
 						"selector": "#pdpa_settings_confirm"
 					}
 				}
+			},
+			{
+				"name": "HIDE_CMP",
+				"action": {
+					"type": "list",
+					"actions": [
+						{
+							"type": "hide",
+							"target": {
+								"selector": ".dpdpa--alwayson"
+							}
+						},
+						{
+							"type": "hide",
+							"target": {
+								"selector": ".dpdpa--popup-sidebar"
+							}
+						},
+						{
+							"type": "hide",
+							"target": {
+								"selector": ".dpdpa--popup-bg"
+							}
+						}
+					]
+				}
 			}
 		]
 	}

--- a/rules/designilpdpa.json
+++ b/rules/designilpdpa.json
@@ -1,0 +1,169 @@
+{
+	"$schema": "../rules.schema.json",
+	"designilpdpa": {
+		"detectors": [
+			{
+				"presentMatcher": {
+					"type": "css",
+					"target": {
+						"selector": ".dpdpa--popup"
+					}
+				},
+				"showingMatcher": {
+					"target": {
+						"selector": ".dpdpa--popup.active"
+					},
+					"type": "css"
+				}
+			}
+		],
+		"methods": [
+			{
+				"name": "OPEN_OPTIONS",
+				"action": {
+					"type": "click",
+					"parent": {
+						"selector": ".dpdpa--popup"
+					},
+					"target": {
+						"selector": "#dpdpa--popup-button-settings"
+					}
+				}
+			},
+			{
+				"name": "DO_CONSENT",
+				"action": {
+					"type": "consent",
+					"consents": [
+						{
+							"type": "B",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input[type=checkbox]"
+								},
+								"parent": {
+									"selector": ".dpdpa--popup-header",
+									"childFilter": {
+										"target": {
+											"selector": ".dpdpa--popup-title",
+											"textFilter": [
+												"คุกกี้เพื่อการวิเคราะห์",
+												"Performance"
+											]
+										}
+									}
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".dpdpa--popup-switch"
+								},
+								"parent": {
+									"selector": ".dpdpa--popup-header",
+									"childFilter": {
+										"target": {
+											"selector": ".dpdpa--popup-title",
+											"textFilter": [
+												"คุกกี้เพื่อการวิเคราะห์",
+												"Performance"
+											]
+										}
+									}
+								}
+							}
+						},
+						{
+							"type": "F",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input[type=checkbox]"
+								},
+								"parent": {
+									"selector": ".dpdpa--popup-header",
+									"childFilter": {
+										"target": {
+											"selector": ".dpdpa--popup-title",
+											"textFilter": [
+												"กลุ่มเป้าหมาย",
+												"Targeting"
+											]
+										}
+									}
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".dpdpa--popup-switch"
+								},
+								"parent": {
+									"selector": ".dpdpa--popup-header",
+									"childFilter": {
+										"target": {
+											"selector": ".dpdpa--popup-title",
+											"textFilter": [
+												"กลุ่มเป้าหมาย",
+												"Targeting"
+											]
+										}
+									}
+								}
+							}
+						},
+						{
+							"type": "A",
+							"matcher": {
+								"type": "checkbox",
+								"target": {
+									"selector": "input[type=checkbox]"
+								},
+								"parent": {
+									"selector": ".dpdpa--popup-header",
+									"childFilter": {
+										"target": {
+											"selector": ".dpdpa--popup-title",
+											"textFilter": [
+												"การใช้งานเว็บไซต์",
+												"Functional"
+											]
+										}
+									}
+								}
+							},
+							"toggleAction": {
+								"type": "click",
+								"target": {
+									"selector": ".dpdpa--popup-switch"
+								},
+								"parent": {
+									"selector": ".dpdpa--popup-header",
+									"childFilter": {
+										"target": {
+											"selector": ".dpdpa--popup-title",
+											"textFilter": [
+												"การใช้งานเว็บไซต์",
+												"Functional"
+											]
+										}
+									}
+								}
+							}
+						}
+					]
+				}
+			},
+			{
+				"name": "SAVE_CONSENT",
+				"action": {
+					"type": "click",
+					"target": {
+						"selector": "#pdpa_settings_confirm"
+					}
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
- Fix from #74 that the cookie consent setter doesn't actually set. Luckily their default should be all off so user shouldn't have already consented to something they don't. Also adding hiding rule and merge the different languages rules.
- Add DesignilPDPA (www.designilpdpa.com) Thai consent management for WordPress, used by bangmod.cloud, webmaster.or.th, dga.or.th.
  - DesignilPDPA seems to allow user to customize both the ID and name of each category. I've tested that it at least can deny everything on the listed websites, but it is not future proof especially since the CMP on their website precheck everything by default.