### PR TITLE
Fix for demorgen.be

### DIFF
--- a/rules/sourcepoint_popup.json
+++ b/rules/sourcepoint_popup.json
@@ -59,7 +59,8 @@
                                     "Options",
                                     "Manage my cookies",
                                     "Settings",
-                                    "Einstellungen"
+                                    "Einstellungen",
+                                    "Instellen"
                                 ]
                             }
                         }


### PR DESCRIPTION
The Flemish news website [demorgen.be](http://www.demorgen.be) was not working correctly because the `sourcepoint_popup` rule did not match on the Flemish/Dutch word for 'Configure', which is 'Instellen'