### PR TITLE
Fix button selector for Yahoo consent form

### DIFF
--- a/rules/yahoo_consent.json
+++ b/rules/yahoo_consent.json
@@ -212,7 +212,7 @@
                 "action": {
                     "type": "click",
                     "target": {
-                        "selector": ".page-footer .actions button.primary[value=\"agree\"]"
+                        "selector": ".page-footer .actions button.secondary[value=\"reject\"]"
                     }
                 },
                 "name": "SAVE_CONSENT"

--- a/rules/yahoo_consent.json
+++ b/rules/yahoo_consent.json
@@ -212,7 +212,7 @@
                 "action": {
                     "type": "click",
                     "target": {
-                        "selector": ".page-footer .actions button.secondary[value=\"reject\"]"
+                        "selector": ".page-footer .actions button.secondary[value=\"save\"]"
                     }
                 },
                 "name": "SAVE_CONSENT"


### PR DESCRIPTION
Fix for Yahoo (https://www.yahoo.com/), a small update on a selector to target correctly the 'Reject all' button of the consent form.

![image](https://user-images.githubusercontent.com/1130363/204154466-b578ab83-2d01-41b0-9bad-6c1d47d5d749.png)
