### PR TITLE
Updated Rule sourcepointpopup

### DIFF
--- a/rules/sourcepoint_popup.json
+++ b/rules/sourcepoint_popup.json
@@ -61,7 +61,10 @@
                                     "Settings",
                                     "Einstellungen",
                                     "Instellen",
-                                    "Mijn instellingen beheren"
+                                    "Mijn instellingen beheren",
+                                    "Hantera cookies",
+                                    "Manage",
+                                    "Configure Preferences"
                                 ]
                             }
                         }


### PR DESCRIPTION
Updated Rule sourcepointpopup: now opens Aftonblade.se, economist.com and vice.com