### PR TITLE
Add support for "Before you continue to Google"-dialog variant

### DIFF
--- a/rules/google_popup.json
+++ b/rules/google_popup.json
@@ -72,7 +72,8 @@
 			    "Fler alternativ",
 			    "Más opciones",
 			    "Mais opções",
-			    "Meer opties"
+			    "Meer opties",
+			    "Więcej opcji"
                         ]
                     }
                 },

--- a/rules/google_popup.json
+++ b/rules/google_popup.json
@@ -63,7 +63,16 @@
                             "Sesuaikan",
                             "Personalizza",
                             "Aanpassen",
-                            "Personnaliser"
+                            "Personnaliser",
+			    "More options",
+			    "Flere alternativer",
+			    "Weitere Optionen",
+			    "Flere valgmuligheder",
+			    "Plus d'options",
+			    "Fler alternativ",
+			    "Más opciones",
+			    "Mais opções",
+			    "Meer opties"
                         ]
                     }
                 },


### PR DESCRIPTION
Only a few common languages for now.
![image](https://user-images.githubusercontent.com/10342989/215733131-d4e705d9-6dbf-432c-b654-fffb29df2f8b.png)

Clicks the more options button which redirects to consent form handled by google-cwiz.