### PR TITLE
Fix various didomi popups

### DIFF
--- a/rules/didomi.io.json
+++ b/rules/didomi.io.json
@@ -173,7 +173,8 @@
                                                 "Mesurer la performance des publicités",
                                                 "Promotion et personnalisation des contenus",
                                                 "Personnalisation du contenu éditorial et mesure de la performance",
-                                                "Mesure et analyse d'audience"
+                                                "Mesure et analyse d'audience",
+                                                "Personnalisation des contenus et des services"
                                             ]
                                         },
                                         "trueAction": {

--- a/rules/didomi.io.json
+++ b/rules/didomi.io.json
@@ -123,7 +123,8 @@
                                                 "Personoitujen mainosten valinta",
                                                 "Cookies Publicitaires et de personnalisation",
                                                 "Promotion de nos contenus, produits et services",
-                                                "Conservation et accès aux informations de géolocalisation à des fins de publicité ciblée"
+                                                "Conservation et accès aux informations de géolocalisation à des fins de publicité ciblée",
+                                                "Publicités personnalisées de l'éditeur"
                                             ]
                                         },
                                         "trueAction": {
@@ -159,7 +160,10 @@
                                                 "Contact",
                                                 "Personnalisation de votre service",
                                                 "Sélectionner du contenu personnalisé",
-                                                "Sélectionner des publicités standard",
+                                                "Sélectionner des publicités standard",  
+                                                "Recommandations personnalisées de programmes",
+                                                "Contenus interactifs proposés par des tiers",
+                                                "Contenus cartographiques et infographiques",
                                                 "Skapa en personanpassad innehållsprofil",
                                                 "Välja personanpassat innehåll",
                                                 "Opprette en personlig innholdsprofil",


### PR DESCRIPTION
Update textFilter for various popular French websites. Addresses europe1.fr #128 (fully) and
consent-o-matic runs on didomi.io websites but not reallly #85 (partly). It might be worth
considering a different selection method (maybe purely selector based) for didomi popups
as website owners appear to customize them.