### PR TITLE
Iubenda CMP - fix for Italian domains

### DIFF
--- a/rules/iubuenda.json
+++ b/rules/iubuenda.json
@@ -90,7 +90,8 @@
                                         "textFilter": [
                                             "Basic interactions & functionalities",
                                             "Interazioni e funzionalità semplici",
-                                            "Functionality"
+                                            "Functionality",
+                                            "Funzionalità"
                                         ]
                                     }
                                 },
@@ -127,7 +128,8 @@
                                             "Experience enhancement",
                                             "Miglioramento dell’esperienza",
                                             "Experience",
-                                            "Expérience"
+                                            "Expérience",
+                                            "Esperienza"
                                         ]
                                     }
                                 },


### PR DESCRIPTION
I've noticed the Plugin was not working with "Functionality" and "Experience" settings for Italian domains.
I've fixed them introducing the correct labels for the DOM selection.

It works: test performed using custom rules of the plugin.

Tested on: ilmessaggero.it, ansa.it, policlinicoumberto1.it