### PR TITLE
Add URLMatcher and OnOffMatcher to schema

### DIFF
--- a/rules.schema.json
+++ b/rules.schema.json
@@ -49,7 +49,8 @@
         "Matcher": {
             "oneOf": [
                 {"$ref": "#/$defs/CssMatcher"},
-                {"$ref": "#/$defs/CheckboxMatcher"}
+                {"$ref": "#/$defs/CheckboxMatcher"},
+                {"$ref": "#/$defs/URLMatcher"}
             ]
         },
         "CssMatcher": {
@@ -80,6 +81,17 @@
                 "type": {"const": "checkbox"},
                 "parent": {"$ref": "#/$defs/DOMSelection"},
                 "target": {"$ref": "#/$defs/DOMSelection"},
+                "negated": {"type": "boolean"}
+            }
+        },
+        "URLMatcher": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["url", "type"],
+            "properties": {
+                "type": {"const": "url"},
+                "url": {"oneOf": [{"type": "array", "items": {"type": "string"}}, {"type": "string"}]},
+                "regexp": {"type": "boolean"},
                 "negated": {"type": "boolean"}
             }
         },

--- a/rules.schema.json
+++ b/rules.schema.json
@@ -50,7 +50,8 @@
             "oneOf": [
                 {"$ref": "#/$defs/CssMatcher"},
                 {"$ref": "#/$defs/CheckboxMatcher"},
-                {"$ref": "#/$defs/URLMatcher"}
+                {"$ref": "#/$defs/URLMatcher"},
+                {"$ref": "#/$defs/OnOffMatcher"}
             ]
         },
         "CssMatcher": {


### PR DESCRIPTION
The visual rule editor keeps deleting URLMatcher instances while editing a ruleset. I believe this is the issue. This also fixes syntax warnings in other editors which support JSONSchema.