### PR TITLE
add URL constraints for `pepper` CMP

### DIFF
--- a/rules/pepper.json
+++ b/rules/pepper.json
@@ -9,6 +9,19 @@
                         "target": {
                             "selector": "div.popover-content"
                         }
+                    },
+                    {
+                        "type": "url",
+                        "url": [
+                            "www.mydealz.de",
+                            "www.hotukdeals.com",
+                            "www.dealabs.com",
+                            "nl.pepper.com",
+                            "www.pepper.pl",
+                            "www.pepper.it",
+                            "www.preisjaeger.at",
+                            "www.chollometro.com"
+                        ]
                     }
                 ],
                 "showingMatcher": [


### PR DESCRIPTION
Adds all EU sites in the Pepper network as URL constraints. Should fix #293, fix #281, fix #284.