### PR TITLE
Updated rule dailymotion.com to address #385

### DIFF
--- a/rules/dailymotion.com.json
+++ b/rules/dailymotion.com.json
@@ -382,7 +382,13 @@
                             }
                         },
                         {
-                            "type": "close"
+                            "type": "ifcss",
+                            "target": {
+                                "selector": ".TCF2ConsentPage__saveButton___56I8A"
+                            },
+                            "trueAction": {
+                                "type": "close"
+                            }
                         }
                     ]
                 },

--- a/rules/dailymotion.com.json
+++ b/rules/dailymotion.com.json
@@ -31,7 +31,8 @@
                     "type": "click",
                     "target": {
                         "selector": ".TCF2Popup__personalize___NeAe-"
-                    }
+                    },
+                    "openInTab": true
                 },
                 "name": "OPEN_OPTIONS"
             },


### PR DESCRIPTION
This should fix the issues #385 
I don't have access to an IOS device to check. The issue seem to be Dailymotion not opening a new tab by default on IOS devices, which the rule is designed for. Now it forces open in new tab, and closes it again afterwards.