### PR TITLE
Update check24.json

### DIFF
--- a/rules/check24.json
+++ b/rules/check24.json
@@ -7,7 +7,7 @@
                     {
                         "type": "css",
                         "target": {
-                            "selector": ".c24-cookie-consent-wrapper"
+                            "selector": ".c24-cookie-consent-notice"
                         }
                     }
                 ],
@@ -15,7 +15,7 @@
                     {
                         "type": "css",
                         "target": {
-                            "selector": ".c24-cookie-consent-wrapper",
+                            "selector": ".c24-cookie-consent-notice",
                             "displayFilter": true
                         }
                     }
@@ -28,7 +28,8 @@
                     "type": "hide",
                     "target": {
                         "selector": ".c24-cookie-consent-wrapper"
-                    }
+                    },
+                    "forceHide": true
                 },
                 "name": "HIDE_CMP"
             },
@@ -80,6 +81,12 @@
                 "name": "DO_CONSENT"
             },
             {
+                "action": {
+                    "type": "click",
+                    "target": {
+                        "selector": ".c24-cookie-consent-buttonlink"
+                    }
+                },
                 "name": "SAVE_CONSENT"
             },
             {


### PR DESCRIPTION
Right now, check24.de will show this state:

![image](https://github.com/cavi-au/Consent-O-Matic/assets/55686147/1d00b90f-7d47-40c1-9f7e-f203799b41ed)

- I added a click action to confirm the current choice (the left button "confirm current selection")
- Replaced "wrapper" with "notice", but I think there is no real difference. I could also revert if wished
- I selected "forceHide", because the popup would otherwise appear on every page

About the last point: not sure if I am doing something wrong, but the ajax call that confirms the consent is still being triggered on every page. If I click through it manually, the ajax calls don't happen again. 