### PR TITLE
Add ability for parent element to be a shadow DOM and create rule for DPG Media

### DIFF
--- a/Extension/Tools.js
+++ b/Extension/Tools.js
@@ -28,7 +28,11 @@ class Tools {
             }
         } else {
             if (parent != null) {
-                possibleTargets = Array.from(parent.querySelectorAll(options.selector));
+                if (!!parent.shadowRoot) {
+                    possibleTargets = Array.from(parent.shadowRoot.querySelectorAll(options.selector));
+                } else {
+                    possibleTargets = Array.from(parent.querySelectorAll(options.selector));
+                }
             } else {
                 if (Tools.base != null) {
                     possibleTargets = Array.from(Tools.base.querySelectorAll(options.selector));

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Consent-O-Matic currently works with these CMPs:
 * cookieLab
 * didomi.io
 * dr.dk
+* DPG Media
 * EvidonBanner
 * EvidonIFrame
 * ez-cookie

--- a/rules-list.json
+++ b/rules-list.json
@@ -52,6 +52,7 @@
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/deichman.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/designilpdpa.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/didomi.io.json",
+    "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/dpgmedia.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/drupalEUCC.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/ecdceuropa.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/elektroniklavpris.json",

--- a/rules/dpgmedia.json
+++ b/rules/dpgmedia.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules.schema.json",
+    "dpgmedia": {
+        "detectors": [
+            {
+                "presentMatcher": [
+                    {
+                        "type": "css",
+                        "target": {
+                            "selector": "#pg-modal"
+                        },
+                        "parent": {
+                            "selector": "#pg-shadow-host"
+                        }
+                    }
+                ],
+                "showingMatcher": [
+                    {
+                        "type": "css",
+                        "target": {
+                            "selector": "#pg-modal"
+                        },
+                        "parent": {
+                            "selector": "#pg-shadow-host"
+                        }
+                    }
+                ]
+            }
+        ],
+        "methods": [
+            {
+                "name": "HIDE_CMP"
+            },
+            {
+                "name": "OPEN_OPTIONS",
+                "action": {
+                    "type": "click",
+                    "target": {
+                        "selector": "#pg-modal #pg-first-layer #pg-footer #pg-configure-btn"
+                    },
+                    "parent": {
+                        "selector": "#pg-shadow-host"
+                    }
+                }
+            },
+            {
+                "name": "DO_CONSENT"
+            },
+            {
+                "name": "SAVE_CONSENT",
+                "action": {
+                    "type": "click",
+                    "target": {
+                        "selector": "#pg-modal #pg-second-layer #pg-footer #pg-reject-btn"
+                    },
+                    "parent": {
+                        "selector": "#pg-shadow-host"
+                    }
+                }
+            },
+            {
+                "name": "UTILITY"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This PR adds support for the parent element to be a shadow DOM/ShadowRoot.

This PR also adds a rule for a number of brands owned by DPG Media that use the consent popup variant that lives in a shadow DOM.

This rule is confirmed to work on at least the following websites:

https://www.gaspedaal.nl
https://www.autotrack.nl