### PR TITLE
Fix TypeError on contentScript.js

### DIFF
--- a/Extension/contentScript.js
+++ b/Extension/contentScript.js
@@ -111,7 +111,7 @@ if (topContentTag){
 }
 window.addEventListener("message", (event)=>{
     try {
-        if(event.data.enforceScrollBehaviours != null) {
+        if(event.data?.enforceScrollBehaviours != null) {
             ConsentEngine.enforceScrollBehaviours(event.data.enforceScrollBehaviours);
         }
     }catch(e) {


### PR DESCRIPTION
Some websites dispatch custom "message" events on windows, which causes console errors because the event lacks the "data" property.