### PR TITLE
fixed bug of undefined selector

### DIFF
--- a/Extension/Tools.js
+++ b/Extension/Tools.js
@@ -12,7 +12,7 @@ export default class Tools {
     static findElement(options, parent = null, multiple = false) {
         let possibleTargets = null;
 
-        if(options.selector.trim() === ":scope") {
+        if(options.selector === undefined || options.selector.trim() === ":scope") {
             //Select current root
             if(parent != null) {
                 possibleTargets = [parent];


### PR DESCRIPTION
As per as issue #471, I fixed it up with this tiny change which is to modify `findElement` to select root when selector is undefined.
Tested it and it works.