### PR TITLE
version bump to trigger mozilla AMO review process

### DIFF
--- a/Extension/manifest.firefox.json
+++ b/Extension/manifest.firefox.json
@@ -3,7 +3,7 @@
 	"description": "Automatic handling of GDPR consent forms",
 	"author": "CAVI - Aarhus University",
 	"homepage_url": "https://github.com/cavi-au/Consent-O-Matic",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"manifest_version": 3,
 	"permissions": [
 		"activeTab",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consent-o-matic",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A chrome extension that tries to do the opposite of Consent-O-Matic",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
We needed to upload a new version to Mozilla so it would trigger the Recommended Extension review process. No code changes made other than a version update.