### PR TITLE
Improve readme by restructuring, adding images and fixing various small issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,36 +91,43 @@ Consent-O-Matic currently works with these CMPs:
 ### Permissions
 
 Consent-O-Matic uses the following set of permissions in the browser when installed:
+
 * Access to read all pages - It searches each page you visit for consent-related popups that it knows how to handle
 * Information about tab URLs - You can turn the extension on/off on a page-by-page basis by clicking the icon. To check if it is enabled it needs to know the address of the page you are visiting
 * Storage - Your preferences and settings are stored directly in your browser
 
 The extension only communicates with the net by itself in two situations:
+
 * When fetching and updating rule lists
 * When you report a website as not working through the extension icon menu
 
 ## Installation
 
 We highly recommend installing directly through the official extension store of your browser:
+
 * [Chrome](https://chrome.google.com/webstore/detail/consent-o-matic/mdjildafknihdffpkfmmpnpoiajfjnjd) (and other Chromium-based browsers)
 * [Firefox](https://addons.mozilla.org/addon/consent-o-matic/) (Desktop / Mobile)
 * [Safari](https://apps.apple.com/gb/app/consent-o-matic/id1606897889) (MacOS / iOS / iPadOS / visionOS)
 * [Edge](https://microsoftedge.microsoft.com/addons/detail/eflcfflijdiekjkegjghbchoncjhfkda) (Windows / MacOS)
 
-
 Installing through the official channels will automatically keep you up-to-date with new versions when they are released.
 
 ### Installing from Archived Release
+
 As an alternative to extension stores you can manually download and extract one of the published versions from the [Releases](https://github.com/cavi-au/Consent-O-Matic/releases) page on Github.
-<br/>If you do that you have to use the developer feature of the browser to [Load Unpacked](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) (Chrome) or [Load Temporary Addon](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#installing) (Firefox) and point it at the manifest.json in the unpacked zip-directory.
+
+If you do that you have to use the developer feature of the browser to [Load Unpacked](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) (Chrome) or [Load Temporary Addon](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#installing) (Firefox) and point it at the manifest.json in the unpacked zip-directory.
 
 ### Building from Source
+
 Lastly, if you intend to review or make changes to the code, you can build and install directly from the source code:
+
 ```
 git clone https://github.com/cavi-au/Consent-O-Matic.git
 cd Consent-O-Matic
 npm install
 ```
+
 and then run one of ```npm run build-firefox``` or ```npm run build-chromium``` or ```npm run build-safari```
 
 For Firefox or Chromium you can now proceed as above for installing release archives but point the browser at the `build` folder or a folder where you extracted the zip from build/dist/. Safari requires loading the XCode project to further build an app.
@@ -158,6 +165,7 @@ If more than 1 detector is added to a CMP, the CMP counts as detected if any of 
 Detectors are the part that detects if a certain rule set should be applied. Basically, if a detector triggers, the methods will be applied.
 
 Detector structure:
+
 ```
 {
    "presentMatcher": [{ ... }],
@@ -188,6 +196,7 @@ SAVE_CONSENT
 ```
 
 Methods take on the form:
+
 ```
 {
    "name": " ... ",
@@ -247,6 +256,7 @@ The selection method works by using the css selector from `selector` and then fi
 * `childFilter` is a fully new DOM selection, that then filters on the original selection, based on if a selection was made by `childFilter` or not.
 
 Here is an example DOM selection:
+
 ```json
 "parent": {
    "selector": ".myParent",
@@ -262,6 +272,7 @@ Here is an example DOM selection:
    "selector": ".myTarget"
 }
 ```
+
 This selector first tries to find the `parent` which is a DOM element with the class `myParent` that is inside an iframe and has a child DOM element with the class `myChild` that contains the text "Gregor".
 
 Then, using this parent as "root", it tries to find a DOM element with the class `myTarget`.
@@ -279,6 +290,7 @@ Actions are the part of Consent-O-Matic that actually do stuff. Some actions do 
 This action simulates a mouse click on its target.
 
 Example:
+
 ```json
 {
    "type": "click",
@@ -299,6 +311,7 @@ In this example we only use a simple `target` with a `textFilter` but full [DOM 
 This action runs a list of actions in order.
 
 Example:
+
 ```json
 {
    "type": "list",
@@ -313,6 +326,7 @@ Example:
 The consent action takes an array of consents, and tries to apply the users consent selections.
 
 Example:
+
 ```json
 {
    "type": "consent",
@@ -327,6 +341,7 @@ Example:
 Some consent forms use a slider to set a consent level, this action supports simulating sliding with such a slider.
 
 Example:
+
 ```json
 {
    "type": "slide",
@@ -355,6 +370,7 @@ The slide event will simulate that the mouse dragged `target` the distance from 
 This action is used as control flow, running another action depending on if a DOM selection finds an element or not.
 
 Example:
+
 ```json
 {
    "type": "ifcss",
@@ -384,6 +400,7 @@ Example:
 This action waits until the DOM selector finds a DOM element that matches. This is mostly used if something in the consent form loads slowly and needs to be waited for.
 
 Example:
+
 ```json
 {
    "type": "waitcss",
@@ -407,6 +424,7 @@ Example:
 If some set of actions needs to be run several times, but with different DOM nodes as root, the for each action can be used. It runs its action 1 time for each DOM element that is selected by its DOM selection; all actions run inside the for each loop will see the DOM as starting from the currently selected node.
 
 Example:
+
 ```json
 {
    "type": "foreach",
@@ -424,6 +442,7 @@ Example:
 This action waits the given amount of milliseconds before continuing.
 
 Example:
+
 ```json
 {
    "type": "wait",
@@ -436,6 +455,7 @@ Example:
 This action sets css class 'ConsentOMatic-CMP-Hider' on the DOM selection. The default css rules will then set opacity to 0 on the element.
 
 Example:
+
 ```json
 {
    "type": "hide",
@@ -450,6 +470,7 @@ Example:
 This action closes the current tab, useful for consent providers like Evidon, which likes to open new tabs with the consent dashboard inside.
 
 Example:
+
 ```json
 {
    "type": "close"
@@ -465,6 +486,7 @@ Matchers are used to check for the presence of some DOM selection, or the state 
 This matcher checks for the presence of a DOM selection, and return that it matches if it exists.
 
 Example:
+
 ```json
 {
    "type": "css",
@@ -479,6 +501,7 @@ Example:
 This matcher checks the state of an `<input type='checkbox' />` and returns that it matches if the checkbox is checked.
 
 Example:
+
 ```json
 {
    "type": "checkbox",
@@ -499,6 +522,7 @@ Each consent has a type, that matches the consent categories inside Consent-O-Ma
 Usually the consent is given either as a toggle, or a set of buttons on/off. Therefore `consent` has a mechanism for each of these cases.
 
 Example:
+
 ```json
 {
    "type": "A",
@@ -643,4 +667,3 @@ Putting it all together, here is a full example of a CMP "myCMP" that has 2 cons
    }
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ If your favorite CMP is missing from the current list, feel free to either creat
    * [CSS](#css)
    * [Checkbox](#checkbox)
 * [Consent](#consent-1)
-* [Consent Categories](#consent-categories)
+   * [Consent Categories](#consent-categories)
 * [Full example](#full-example)
 
 ### Basic Structure

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ dealing with the CMP popup when it is detected.
 
 Each CMP is a named entry and contains 2 parts, `detectors` and `methods`.
 
-```
+```json
 {
    "myCMP": {
       "detectors": [ ... ],
@@ -178,7 +178,7 @@ Detectors are the part that detects if a certain rule set should be applied. Bas
 
 Detector structure:
 
-```
+```json
 {
    "presentMatcher": [{ ... }],
    "showingMatcher": [{ ... }]
@@ -209,7 +209,7 @@ SAVE_CONSENT
 
 Methods take on the form:
 
-```
+```json
 {
    "name": " ... ",
    "action": { ... }

--- a/README.md
+++ b/README.md
@@ -180,15 +180,15 @@ If your favorite CMP is missing from the current list, feel free to either creat
 A rule list for Consent-O-Matic is a JSON structure that contains the rules for detecting a CMP (Consent Management Provider), and
 dealing with the CMP popup when it is detected.
 
-Each CMP is a named entry and contains 2 parts, `detectors` and `methods`.
+Each CMP is a named entry and contains 2 parts, `detectors` and `methods`. Name should correspond to correctly capitalized and whitespaced name of the CMP (will be shown in the About section of extension's settings).
 
 ```json
 {
-   "myCMP": {
+   "MyCMP": {
       "detectors": [ ... ],
       "methods": [ ... ]
    },
-   "anotherCMP": {
+   "AnotherCMP": {
       "detectors": [ ... ],
       "methods": [ ... ]
    },
@@ -595,11 +595,11 @@ As seen in the addon settings, in the same order:
 
 ### Full example
 
-Putting it all together, here is a full example of a CMP "myCMP" that has 2 consent categories to toggle.
+Putting it all together, here is a full example of a CMP "MyCMP" that has 2 consent categories to toggle.
 
 ```json
 {
-   "myCMP": {
+   "MyCMP": {
       "detectors": [
          {
             "presentMatcher": {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
     * [Consent Categories](#consent-categories)
     * [Full example](#full-example)
 
-# Introduction
+## Introduction
 
 You like websites to respect your right to privacy, and your browser clears cookies when you close it.
 Consequently, you get the same cookie-consent box each and every time you visit the same websites. And you tire of submitting the same information over and over. If only there were a way to automate your way out of this pickle? Lucky for you, Consent-O-Matic exists.
@@ -37,7 +37,7 @@ Consent-O-Matic is a browser extension that recognizes a great deal of those CMP
 
 And since it's an open project by the Centre for Advanced Visualisation and Interaction (CAVI) at Aarhus University, regular people can contribute by adding new rules, updating old rules, or even adding to the documentation (like these very paragraphs you're reading now, written by someone who just happened to discover the project and wanted to help) to make the extension even easier for others to use.
 
-## Further reading
+### Further reading
 
 Paper: [Dark Patterns After the GDPR](https://doi.org/10.1145/3313831.3376321)
 
@@ -45,7 +45,7 @@ PDF: [Dark Patterns After the GDPR](https://arxiv.org/pdf/2001.02479.pdf)
 
 Press: [Virksomheder narrer brugerne til mere dataovervågning (PROSA, March 2020, in Danish)](https://www.prosa.dk/artikel/virksomheder-narrer-brugerne-til-mere-dataovervaagning/)<sup>[\[Internet Archive\]](https://web.archive.org/web/20200511044414/https://www.prosa.dk/artikel/virksomheder-narrer-brugerne-til-mere-dataovervaagning/)</sup>
 
-## Compatible CMPs
+### Compatible CMPs
 
 Consent-O-Matic currently works with these CMPs:
 
@@ -88,7 +88,7 @@ Consent-O-Matic currently works with these CMPs:
 * Webedia
 * wordpressgdpr
 
-## Permissions
+### Permissions
 
 Consent-O-Matic uses the following set of permissions in the browser when installed:
 * Access to read all pages - It searches each page you visit for consent-related popups that it knows how to handle
@@ -99,7 +99,7 @@ The extension only communicates with the net by itself in two situations:
 * When fetching and updating rule lists
 * When you report a website as not working through the extension icon menu
 
-# Installation
+## Installation
 
 We highly recommend installing directly through the official extension store of your browser:
 * [Chrome](https://chrome.google.com/webstore/detail/consent-o-matic/mdjildafknihdffpkfmmpnpoiajfjnjd) (and other Chromium-based browsers)
@@ -110,11 +110,11 @@ We highly recommend installing directly through the official extension store of 
 
 Installing through the official channels will automatically keep you up-to-date with new versions when they are released.
 
-## Installing from Archived Release
+### Installing from Archived Release
 As an alternative to extension stores you can manually download and extract one of the published versions from the [Releases](https://github.com/cavi-au/Consent-O-Matic/releases) page on Github.
 <br/>If you do that you have to use the developer feature of the browser to [Load Unpacked](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) (Chrome) or [Load Temporary Addon](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#installing) (Firefox) and point it at the manifest.json in the unpacked zip-directory.
 
-## Building from Source
+### Building from Source
 Lastly, if you intend to review or make changes to the code, you can build and install directly from the source code:
 ```
 git clone https://github.com/cavi-au/Consent-O-Matic.git
@@ -127,14 +127,11 @@ For Firefox or Chromium you can now proceed as above for installing release arch
 
 We do not recommend installing from source.
 
-
-
-
-# Extending Consent-O-Matic
+## Extending Consent-O-Matic
 
 If your favorite CMP is missing from the current list, feel free to either create a custom list that you can add (click the extension icon in your browser, click "More add-on settings", click "Rule lists", and enter the URL of your custom list.). If you **really** want to contribute, feel free to create a Pull Request while you're at it.
 
-## Basic Structure
+### Basic Structure
 
 A rule list for Consent-O-Matic is a JSON structure that contains the rules for detecting a CMP (Consent Management Provider), and
 dealing with the CMP popup when it is detected.
@@ -156,7 +153,7 @@ Each CMP is a named entry and contains 2 parts, `detectors` and `methods`.
 
 If more than 1 detector is added to a CMP, the CMP counts as detected if any of the detectors trigger.
 
-### Detectors
+#### Detectors
 
 Detectors are the part that detects if a certain rule set should be applied. Basically, if a detector triggers, the methods will be applied.
 
@@ -176,7 +173,7 @@ Both the present and showing matcher follow the common structure of [`Matchers`]
 
 Both the present and showing matcher can be multiple matchers, only triggering the detector if all of the matchers (respectively for present and showing) apply.
 
-### Methods
+#### Methods
 
 Methods are collections of actions. There are 4 methods supported by Consent-O-Matic. `OPEN_OPTIONS`, `DO_CONSENT`, `SAVE_CONSENT`, `HIDE_CMP`
 
@@ -200,7 +197,9 @@ Methods take on the form:
 
 where the name is one of the 4 supported methods and action is the [action](#actions) to execute.
 
-## DOM Selection
+---
+
+### DOM Selection
 
 Most actions and matchers have some target that they apply to. For this reason, Consent-O-Matic has a DOM selection mechanism that can easily help with selecting the correct DOM element.
 
@@ -269,11 +268,13 @@ Then, using this parent as "root", it tries to find a DOM element with the class
 
 This could then be the target of an action or matcher.
 
-## Actions
+---
+
+### Actions
 
 Actions are the part of Consent-O-Matic that actually do stuff. Some actions do something to a target selection, others have to do with control flow.
 
-### Click
+#### Click
 
 This action simulates a mouse click on its target.
 
@@ -293,7 +294,7 @@ Example:
 
 In this example we only use a simple `target` with a `textFilter` but full [DOM selection](#dom-selection) is supported.
 
-### List
+#### List
 
 This action runs a list of actions in order.
 
@@ -307,7 +308,7 @@ Example:
 
 `actions` is an array of actions that will all be run in order.
 
-### Consent
+#### Consent
 
 The consent action takes an array of consents, and tries to apply the users consent selections.
 
@@ -321,7 +322,7 @@ Example:
 
 `consents` is an array of [Consent](#consent-1) types
 
-### Slide
+#### Slide
 
 Some consent forms use a slider to set a consent level, this action supports simulating sliding with such a slider.
 
@@ -349,7 +350,7 @@ Example:
 
 The slide event will simulate that the mouse dragged `target` the distance from `target` to `dragTarget` on the given `axis`.
 
-### If Css
+#### If Css
 
 This action is used as control flow, running another action depending on if a DOM selection finds an element or not.
 
@@ -378,7 +379,7 @@ Example:
 `trueAction` is an action that will be run if the DOM selection finds an element.
 `falseAction` will be run when the DOM selection does not find an element.
 
-### Wait For Css
+#### Wait For Css
 
 This action waits until the DOM selector finds a DOM element that matches. This is mostly used if something in the consent form loads slowly and needs to be waited for.
 
@@ -401,7 +402,7 @@ Example:
 
 `negated` makes wait for css wait until the target is NOT found.
 
-### For Each
+#### For Each
 
 If some set of actions needs to be run several times, but with different DOM nodes as root, the for each action can be used. It runs its action 1 time for each DOM element that is selected by its DOM selection; all actions run inside the for each loop will see the DOM as starting from the currently selected node.
 
@@ -418,7 +419,7 @@ Example:
 
 `action` is the action to run for each found DOM element.
 
-### Wait
+#### Wait
 
 This action waits the given amount of milliseconds before continuing.
 
@@ -430,7 +431,7 @@ Example:
 }
 ```
 
-### Hide
+#### Hide
 
 This action sets css class 'ConsentOMatic-CMP-Hider' on the DOM selection. The default css rules will then set opacity to 0 on the element.
 
@@ -444,7 +445,7 @@ Example:
 }
 ```
 
-### Close
+#### Close
 
 This action closes the current tab, useful for consent providers like Evidon, which likes to open new tabs with the consent dashboard inside.
 
@@ -455,11 +456,11 @@ Example:
 }
 ```
 
-## Matchers
+### Matchers
 
 Matchers are used to check for the presence of some DOM selection, or the state of some DOM selection.
 
-### Css
+#### Css
 
 This matcher checks for the presence of a DOM selection, and return that it matches if it exists.
 
@@ -473,7 +474,7 @@ Example:
 }
 ```
 
-### Checkbox
+#### Checkbox
 
 This matcher checks the state of an `<input type='checkbox' />` and returns that it matches if the checkbox is checked.
 
@@ -487,7 +488,9 @@ Example:
 }
 ```
 
-## Consent
+---
+
+### Consent
 
 This is what is used inside [Consent Actions](#consent) and defines the actual consent that the user should be giving or not giving.
 
@@ -516,7 +519,7 @@ Example:
 
 If `toggleAction` and `matcher` is present on the content config, toggleAction will be used, if one of them is missing, `trueAction`/`falseAction` will be used instead.
 
-### Consent Categories
+#### Consent Categories
 
 As seen in the addon settings, in the same order:
 
@@ -527,7 +530,9 @@ As seen in the addon settings, in the same order:
 * F: Ad selection, delivery, and reporting
 * X: Other Purposes
 
-## Full example
+---
+
+### Full example
 
 Putting it all together, here is a full example of a CMP "myCMP" that has 2 consent categories to toggle.
 

--- a/README.md
+++ b/README.md
@@ -36,42 +36,12 @@
    </div>
 </td></tr></table>
 
-* [Introduction](#introduction)
-    * [Further reading](#further-reading)
-    * [Compatible CMPs](#compatible-cmps)
-    * [Permissions](#permissions)
-* [Installation](#installation)
-* [Extending Consent-O-Matic](#extending-consent-o-matic)
-    * [Basic Structure](#basic-structure)
-        * [Detectors](#detectors)
-        * [Methods](#methods)
-    * [DOM Selection](#dom-selection)
-    * [Actions](#actions)
-        * [Click](#click)
-        * [List](#list)
-        * [Consent](#consent)
-        * [Slide](#slide)
-        * [If CSS](#if-css)
-        * [Wait For CSS](#wait-for-css)
-        * [For Each](#for-each)
-        * [Wait](#wait)
-        * [Hide](#hide)
-        * [Close](#close)
-    * [Matchers](#matchers)
-        * [CSS](#css)
-        * [Checkbox](#checkbox)
-    * [Consent](#consent-1)
-    * [Consent Categories](#consent-categories)
-    * [Full example](#full-example)
-
-## Introduction
-
 You like websites to respect your right to privacy, and your browser clears cookies when you close it.
 Consequently, you get the same cookie-consent box each and every time you visit the same websites. And you tire of submitting the same information over and over. If only there were a way to automate your way out of this pickle? Lucky for you, Consent-O-Matic exists.
 
 Consent-O-Matic is a browser extension that recognizes a great deal of those CMP (Consent Management Provider) pop-ups that we've all grown to both love and hate. But since you've told it your cookie preferences upon installation, it will autofill those forms for you when it encounters them—and let you know that it did so, with a satisfying little checkmark next to its icon. Nice.
 
-And since it's an open project by the Centre for Advanced Visualisation and Interaction (CAVI) at Aarhus University, regular people can contribute by adding new rules, updating old rules, or even adding to the documentation (like these very paragraphs you're reading now, written by someone who just happened to discover the project and wanted to help) to make the extension even easier for others to use.
+And since it's an open project by the Centre for Advanced Visualisation and Interaction (CAVI) at Aarhus University, regular people can [contribute by adding new rules, updating old rules](#extending-consent-o-matic), or even adding to the documentation (like these very paragraphs you're reading now, written by someone who just happened to discover the project and wanted to help) to make the extension even easier for others to use.
 
 ### Further reading
 
@@ -81,7 +51,7 @@ PDF: [Dark Patterns After the GDPR](https://arxiv.org/pdf/2001.02479.pdf)
 
 Press: [Virksomheder narrer brugerne til mere dataovervågning (PROSA, March 2020, in Danish)](https://www.prosa.dk/artikel/virksomheder-narrer-brugerne-til-mere-dataovervaagning/)<sup>[\[Internet Archive\]](https://web.archive.org/web/20200511044414/https://www.prosa.dk/artikel/virksomheder-narrer-brugerne-til-mere-dataovervaagning/)</sup>
 
-### Compatible CMPs
+## Compatible CMPs
 
 Consent-O-Matic currently works with these CMPs:
 
@@ -136,7 +106,7 @@ Consent-O-Matic currently works with these CMPs:
 
 </td></tr></table>
 
-### Permissions
+## Permissions
 
 Consent-O-Matic uses the following set of permissions in the browser when installed:
 
@@ -180,6 +150,30 @@ We do not recommend installing from source.
 ## Extending Consent-O-Matic
 
 If your favorite CMP is missing from the current list, feel free to either create a custom list that you can add (click the extension icon in your browser, click "More add-on settings", click "Rule lists", and enter the URL of your custom list.). If you **really** want to contribute, feel free to create a Pull Request while you're at it.
+
+### Rule elements
+
+* [Basic Structure](#basic-structure)
+   * [Detectors](#detectors)
+   * [Methods](#methods)
+* [DOM Selection](#dom-selection)
+* [Actions](#actions)
+   * [Click](#click)
+   * [List](#list)
+   * [Consent](#consent)
+   * [Slide](#slide)
+   * [If CSS](#if-css)
+   * [Wait For CSS](#wait-for-css)
+   * [For Each](#for-each)
+   * [Wait](#wait)
+   * [Hide](#hide)
+   * [Close](#close)
+* [Matchers](#matchers)
+   * [CSS](#css)
+   * [Checkbox](#checkbox)
+* [Consent](#consent-1)
+* [Consent Categories](#consent-categories)
+* [Full example](#full-example)
 
 ### Basic Structure
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,41 @@
 # Consent-O-Matic
 
+<table><tr><td>
+   <picture>
+     <source srcset="Extension/logo.svg" width="150" media="(width >= 710px)">
+     <img src="Extension/logo.svg" width="550" alt="">
+   </picture>
+</td><td>
+   <div>
+      <a href="https://chromewebstore.google.com/detail/consent-o-matic/mdjildafknihdffpkfmmpnpoiajfjnjd">
+         <picture>
+            <source srcset="https://i.imgur.com/XBIE9pk.png" height="60" media="(width >= 710px)">
+            <img src="https://i.imgur.com/XBIE9pk.png" width="56%" alt="Chrome Web Store (also for Chromium-based browsers)">
+         </picture>
+      </a>
+      <a href="https://addons.mozilla.org/en-US/firefox/addon/consent-o-matic/">
+         <picture>
+            <source srcset="https://i.imgur.com/ZluoP7T.png" height="60" media="(width >= 710px)">
+            <img src="https://i.imgur.com/ZluoP7T.png" width="41%" alt="Firefox add-ons">
+         </picture>
+      </a>
+   </div>
+   <div>
+      <a href="https://apps.apple.com/us/app/consent-o-matic/id1606897889">
+         <picture>
+            <source srcset="https://i.imgur.com/LC92P1Y.png" height="60" media="(width >= 710px)">
+            <img src="https://i.imgur.com/LC92P1Y.png" width="56%" alt="Mac App Store for Safari on iOS and macOS">
+         </picture>
+      </a>
+      <a href="https://microsoftedge.microsoft.com/addons/detail/consentomatic/eflcfflijdiekjkegjghbchoncjhfkda">
+         <picture>
+            <source srcset="https://i.imgur.com/Jog9cQP.png" height="60" media="(width >= 710px)">
+            <img src="https://i.imgur.com/Jog9cQP.png" width="41%" alt="Microsoft Store for Edge">
+         </picture>
+      </a>
+   </div>
+</td></tr></table>
+
 * [Introduction](#introduction)
     * [Further reading](#further-reading)
     * [Compatible CMPs](#compatible-cmps)
@@ -115,14 +151,9 @@ The extension only communicates with the net by itself in two situations:
 
 ## Installation
 
-We highly recommend installing directly through the official extension store of your browser:
+We highly recommend installing directly through the official extension store of your browser ([mentioned at the top](#consent-o-matic)). Installing through the official channels will automatically keep you up-to-date with new versions when they are released.
 
-* [Chrome](https://chrome.google.com/webstore/detail/consent-o-matic/mdjildafknihdffpkfmmpnpoiajfjnjd) (and other Chromium-based browsers)
-* [Firefox](https://addons.mozilla.org/addon/consent-o-matic/) (Desktop / Mobile)
-* [Safari](https://apps.apple.com/gb/app/consent-o-matic/id1606897889) (MacOS / iOS / iPadOS / visionOS)
-* [Edge](https://microsoftedge.microsoft.com/addons/detail/eflcfflijdiekjkegjghbchoncjhfkda) (Windows / MacOS)
-
-Installing through the official channels will automatically keep you up-to-date with new versions when they are released.
+It is also possible to get the extension by other means.
 
 ### Installing from Archived Release
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Press: [Virksomheder narrer brugerne til mere dataovervågning (PROSA, March 202
 
 Consent-O-Matic currently works with these CMPs:
 
+<table><tr><td valign="top">
+
 * Autodesk
 * begadi.com
 * chandago
@@ -62,6 +64,10 @@ Consent-O-Matic currently works with these CMPs:
 * dr.dk
 * DPG Media
 * EvidonBanner
+
+</td>
+<td valign="top">
+
 * EvidonIFrame
 * ez-cookie
 * future
@@ -75,6 +81,10 @@ Consent-O-Matic currently works with these CMPs:
 * quantcast2
 * SFR
 * sharethis
+
+</td>
+<td valign="top">
+
 * sourcepoint
 * sourcepointframe
 * sourcepointpopup
@@ -87,6 +97,8 @@ Consent-O-Matic currently works with these CMPs:
 * uniconsent
 * Webedia
 * wordpressgdpr
+
+</td></tr></table>
 
 ### Permissions
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
         * [List](#list)
         * [Consent](#consent)
         * [Slide](#slide)
-        * [If Css](#if-css)
-        * [Wait For Css](#wait-for-css)
+        * [If CSS](#if-css)
+        * [Wait For CSS](#wait-for-css)
         * [For Each](#for-each)
         * [Wait](#wait)
         * [Hide](#hide)
         * [Close](#close)
     * [Matchers](#matchers)
-        * [Css](#css)
+        * [CSS](#css)
         * [Checkbox](#checkbox)
     * [Consent](#consent-1)
     * [Consent Categories](#consent-categories)
@@ -255,7 +255,7 @@ There are 2 parts, `parent` and `target`. The `parent` is optional but if it exi
 
 All the parameters to `parent` and `target` except `selector` are optional.
 
-The selection method works by using the css selector from `selector` and then filtering the resulting DOM nodes via the various available filters:
+The selection method works by using the CSS selector from `selector` and then filtering the resulting DOM nodes via the various available filters:
 
 * `textFilter` filters all nodes that do not include the given text. It can also be given as an array `"textFilter":["filter1", "filter2"]` and then it filters all nodes that do not include one of the given text filters.
 
@@ -377,7 +377,7 @@ Example:
 
 The slide event will simulate that the mouse dragged `target` the distance from `target` to `dragTarget` on the given `axis`.
 
-#### If Css
+#### If CSS
 
 This action is used as control flow, running another action depending on if a DOM selection finds an element or not.
 
@@ -407,7 +407,7 @@ Example:
 `trueAction` is an action that will be run if the DOM selection finds an element.
 `falseAction` will be run when the DOM selection does not find an element.
 
-#### Wait For Css
+#### Wait For CSS
 
 This action waits until the DOM selector finds a DOM element that matches. This is mostly used if something in the consent form loads slowly and needs to be waited for.
 
@@ -429,7 +429,7 @@ Example:
 
 `waitTime` determines the time between retry attempts. Defaults to 250.
 
-`negated` makes wait for css wait until the target is NOT found.
+`negated` makes "Wait For CSS" wait until the target is NOT found.
 
 #### For Each
 
@@ -464,7 +464,7 @@ Example:
 
 #### Hide
 
-This action sets css class 'ConsentOMatic-CMP-Hider' on the DOM selection. The default css rules will then set opacity to 0 on the element.
+This action sets CSS class 'ConsentOMatic-CMP-Hider' on the DOM selection. The default CSS rules will then set opacity to 0 on the element.
 
 Example:
 
@@ -493,7 +493,7 @@ Example:
 
 Matchers are used to check for the presence of some DOM selection, or the state of some DOM selection.
 
-#### Css
+#### CSS
 
 This matcher checks for the presence of a DOM selection, and return that it matches if it exists.
 
@@ -549,7 +549,7 @@ Example:
 
 `toggleAction` this action is used to select consent if the popup uses a toggle or a switch to communicate consent. The action will be run if the matcher says the consent is in a state different from what the user has asked it to be, otherwise it will not be run.
 
-`matcher` is the matcher used to check which state the consent is in. For a [checkbox matcher](#checkbox), the consent is given if the checkbox is checked. For a [css matcher](#css) the consent is given if the matcher finds a DOM selection.
+`matcher` is the matcher used to check which state the consent is in. For a [checkbox matcher](#checkbox), the consent is given if the checkbox is checked. For a [CSS matcher](#css) the consent is given if the matcher finds a DOM selection.
 
 `trueAction` and `falseAction` are actions used if consent instead has to be given by pressing one of two buttons, rather than being toggled on/off. These will be run depending on the user's selection of consent. If the user has given consent for this category type, the `trueAction` will be run, and `falseAction` will be run if the user has not given consent to this category type.
 


### PR DESCRIPTION
Most importantly moved the useful sections such as description of the extension and its download links to the top of the readme file. Also added logo and images linking to each platform's extension store. See individual commit messages for more details.