### PR TITLE
Document the workings of the "Let us know!" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Because Consent-O-Matic is an open-source project, anyone can contribute to its 
 
 Consent-O-Matic currently works with more than 200 CMPs (see full list [here](https://github.com/cavi-au/Consent-O-Matic/tree/master/rules)), including major platforms like UserCentrics, CookieBot, OneTrust, as well as cookie banners for specific websites. 
 
-## Permissions
+## Privacy
 
 Consent-O-Matic uses the following set of permissions in the browser when installed:
 
@@ -70,7 +70,7 @@ Consent-O-Matic uses the following set of permissions in the browser when instal
 * Information about tab URLs - You can turn the extension on/off on a page-by-page basis by clicking the icon. To check if it is enabled it needs to know the address of the page you are visiting
 * Storage - Your preferences and settings are stored directly in your browser
 
-The extension only communicates with the net by itself in two situations:
+The extension only communicates with the web in two situations:
 
 * When fetching and updating rule lists
 * When you report a website as not working through the extension icon menu

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Consent-O-Matic uses the following set of permissions in the browser when instal
 The extension only communicates with the web in two situations:
 
 * When fetching and updating rule lists
-* When you report a website as not working through the extension icon menu
+* When you report a website as not working through the extension icon menu (the **Let us know!** button)
+
+The URL of the website reported through the extension icon is [sent](https://github.com/cavi-au/Consent-O-Matic/blob/master/Extension/popup.js#L50) to a [website hosted by Aarhus University](https://gdprconsent.projects.cavi.au.dk/report.php) in the form of a URI-encoded query string (e.g., LinkedIn will be reported as `https://gdprconsent.projects.cavi.au.dk/report.php?url=www.linkedin.com`). These submissions will be reflected on a [page containing summary of all submissions](https://gdprconsent.projects.cavi.au.dk/reports.php), from which you can see the number of submissions per domain name.
 
 ## Installation
 


### PR DESCRIPTION
There have been a few requests for clearer documentation regarding the Let us know! button. Currently it feels like it reports into the ether, so it would be nice to have the process documented at least in the readme.

Additionally, changed the wording and heading name for the section containing the newly added documentation.

@MidasN, can you please verify if the process logic/terminology is correct?

Refs #519, closes #341.