### PR TITLE
Add rule for wcp

### DIFF
--- a/rules/wcp.json
+++ b/rules/wcp.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules.schema.json",
+	"wcp": {
+		"detectors": [
+			{
+				"presentMatcher": [
+					{
+						"type": "css",
+						"target": {
+							"selector": "#wcpConsentBannerCtrl"
+						}
+					}
+				]
+			}
+		],
+		"methods": [
+			{
+				"name": "DO_CONSENT",
+				"action": {
+					"type": "click",
+					"target": {
+						"selector": "#wcpConsentBannerCtrl div:last-child button:nth-child(2)"
+					}
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
This is used on https://learn.microsoft.com/ (and potentially other microsoft-related sites).

It's a basic first attempt that auto-rejects everything based on where the buttons are in the DOM. I didn't want to use text filtering because I thought it'd break with non-English languages...

I've tested it with Firefox Nightly 146 (1.11.2025) on Linux, and it worked on my machine (tm). If you got questions/suggestions, let me know.