### PR TITLE
New rule/fides

### DIFF
--- a/rules-list.json
+++ b/rules-list.json
@@ -64,6 +64,7 @@
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/facebook.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/fanatical.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/fastcmp.json",
+    "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/fides.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/Flightaware.com.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/flysas.json",
     "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules/future.json",

--- a/rules/fides.json
+++ b/rules/fides.json
@@ -30,6 +30,8 @@
                         "selector": "#fides-manage-preferences-button, button.fides-manage-preferences-button",
                         "textFilter": [
                             "Your Privacy Choices",
+                            "Customise",
+                            "Customize",
                             "Manage preferences",
                             "Manage privacy preferences"
                         ],

--- a/rules/fides.json
+++ b/rules/fides.json
@@ -322,6 +322,19 @@
                     ]
                 },
                 "name": "DO_CONSENT"
+            },
+            {
+                "action": {
+                    "type": "click",
+                    "target": {
+                        "selector": "#fides-save-button, button.fides-save-button",
+                        "textFilter": [
+                            "Save"
+                        ],
+                        "displayFilter": true
+                    }
+                },
+                "name": "SAVE_CONSENT"
             }
         ]
     }

--- a/rules/fides.json
+++ b/rules/fides.json
@@ -36,6 +36,292 @@
                     }
                 },
                 "name": "OPEN_OPTIONS"
+            },
+            {
+                "action": {
+                    "type": "consent",
+                    "consents": [
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Store and/or access information on a device"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Store and/or access information on a device"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "D"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Use limited data to select advertising"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Use limited data to select advertising"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "F"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Create profiles for personalised advertising",
+                                        "Create profiles for personalized advertising"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Create profiles for personalised advertising",
+                                        "Create profiles for personalized advertising"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "F"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Use profiles to select personalised advertising",
+                                        "Use profiles to select personalized advertising"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Use profiles to select personalised advertising",
+                                        "Use profiles to select personalized advertising"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "F"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Measure advertising performance"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Measure advertising performance"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "B"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Measure content performance"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Measure content performance"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "B"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Understand audiences through statistics",
+                                        "Understand audiences"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Understand audiences through statistics",
+                                        "Understand audiences"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "B"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Develop and improve services",
+                                        "Develop and improve products"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Develop and improve services",
+                                        "Develop and improve products"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "E"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Use precise geolocation data"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Use precise geolocation data"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "X"
+                        },
+                        {
+                            "matcher": {
+                                "type": "checkbox",
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Actively scan device characteristics"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                }
+                            },
+                            "toggleAction": {
+                                "parent": {
+                                    "selector": ".fides-notice-toggle",
+                                    "textFilter": [
+                                        "Actively scan device characteristics"
+                                    ]
+                                },
+                                "target": {
+                                    "selector": "input.fides-toggle-input"
+                                },
+                                "type": "click"
+                            },
+                            "type": "X"
+                        }
+                    ]
+                },
+                "name": "DO_CONSENT"
             }
         ]
     }

--- a/rules/fides.json
+++ b/rules/fides.json
@@ -21,6 +21,22 @@
                     }
                 ]
             }
+        ],
+        "methods": [
+            {
+                "action": {
+                    "type": "click",
+                    "target": {
+                        "selector": "#fides-manage-preferences-button, button.fides-manage-preferences-button",
+                        "textFilter": [
+                            "Manage preferences",
+                            "Manage privacy preferences"
+                        ],
+                        "displayFilter": true
+                    }
+                },
+                "name": "OPEN_OPTIONS"
+            }
         ]
     }
 }

--- a/rules/fides.json
+++ b/rules/fides.json
@@ -7,7 +7,7 @@
                     {
                         "type": "css",
                         "target": {
-                            "selector": "#fides-overlay, #fides-modal, #fides-banner"
+                            "selector": "#fides-overlay, #fides-modal, #fides-banner, #fides-banner-container"
                         }
                     }
                 ],
@@ -15,7 +15,7 @@
                     {
                         "type": "css",
                         "target": {
-                            "selector": "#fides-overlay, #fides-banner, #fides-modal",
+                            "selector": "#fides-overlay, #fides-banner, #fides-banner-container, #fides-modal",
                             "displayFilter": true
                         }
                     }

--- a/rules/fides.json
+++ b/rules/fides.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://raw.githubusercontent.com/cavi-au/Consent-O-Matic/master/rules.schema.json",
+    "fides": {
+        "detectors": [
+            {
+                "presentMatcher": [
+                    {
+                        "type": "css",
+                        "target": {
+                            "selector": "#fides-overlay, #fides-modal, #fides-banner"
+                        }
+                    }
+                ],
+                "showingMatcher": [
+                    {
+                        "type": "css",
+                        "target": {
+                            "selector": "#fides-overlay[aria-hidden='false'], #fides-banner[aria-hidden='false']",
+                            "displayFilter": true
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/rules/fides.json
+++ b/rules/fides.json
@@ -29,6 +29,7 @@
                     "target": {
                         "selector": "#fides-manage-preferences-button, button.fides-manage-preferences-button",
                         "textFilter": [
+                            "Your Privacy Choices",
                             "Manage preferences",
                             "Manage privacy preferences"
                         ],
@@ -329,7 +330,9 @@
                     "target": {
                         "selector": "#fides-save-button, button.fides-save-button",
                         "textFilter": [
-                            "Save"
+                            "Confirm My Choices",
+                            "Save",
+                            "Confirm"
                         ],
                         "displayFilter": true
                     }

--- a/rules/fides.json
+++ b/rules/fides.json
@@ -15,7 +15,7 @@
                     {
                         "type": "css",
                         "target": {
-                            "selector": "#fides-overlay[aria-hidden='false'], #fides-banner[aria-hidden='false']",
+                            "selector": "#fides-overlay, #fides-banner, #fides-modal",
                             "displayFilter": true
                         }
                     }


### PR DESCRIPTION
## Description
This PR adds a rule set for utilizing Ethyca's Fides consent infrastructure. These additions expand coverage across major digital media outlets, E-Commerce applications, and tech services.

### Verified Domains that use Fides:
- **Publishing & Media:** `nytimes.com`, `axios.com`, `condenast.com`, `vogue.com`, `wired.com`, `newyorker.com`, `vanityfair.com`
- **Tech & Services:** `surveymonkey.com`, `casper.com`, `mozilla.org`, `ramp.com`, `justpark.com`

### Note on Exclusions (Away Travel)
I actively tested `awaytravel.com` as well, but it is **not** included in this PR. 

The production implementation on Away completely strips out standard Fides CSS layout hooks (such as `#fides-overlay`, `#fides-modal`, and `#fides-banner`). Because the default layout branding is gone, the current detectors fail to catch it. I may follow up with a separate PR later using custom targeted selectors specifically for their altered layout markup.